### PR TITLE
Documentation fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Honeycomb is an open-source honeypot framework created by Cymmetria_.
 Honeycomb allows running honeypots with various integrations from a public library of plugins at https://github.com/Cymmetria/honeycomb_plugins
 
 Writing new honeypot services and integrations for honeycomb is super easy!
-See the `plugins repo <http://honeycomb.cymmetria.com/projects/honeycomb-plugins/en/latest/>` for more info.
+See the `plugins repo <http://honeycomb.cymmetria.com/projects/honeycomb-plugins/en/latest/>`_ for more info.
 
 Full CLI documentation can be found at http://honeycomb.cymmetria.com/en/latest/cli.html
 

--- a/README.rst
+++ b/README.rst
@@ -29,10 +29,10 @@ Honeycomb is an open-source honeypot framework created by Cymmetria_.
 
 .. _Cymmetria: https://cymmetria.com
 
-Honeycomb allows running honeypots with various integrations from a public library of plugins from https://github.com/Cymmetria/honeycomb_plugins
+Honeycomb allows running honeypots with various integrations from a public library of plugins at https://github.com/Cymmetria/honeycomb_plugins
 
 Writing new honeypot services and integrations for honeycomb is super easy!
-See the plugins repo for more info.
+See the `plugins repo <http://honeycomb.cymmetria.com/projects/honeycomb-plugins/en/latest/>` for more info.
 
 Full CLI documentation can be found at http://honeycomb.cymmetria.com/en/latest/cli.html
 

--- a/docs/using-docker.rst
+++ b/docs/using-docker.rst
@@ -13,7 +13,7 @@ This actually resembles configuring a docker environment, where the user needs t
 
 A yml configuration that specifies all of the desired configurations (services, integrations, etc.) will be supplied to Honeycomb, and it will work like a state-machine to reach the desired state before finally running the service.
 
-An example Honeycomb file can be found on `github <https://github.com/Cymmetria/Honeycomb/blob/master/honeycomb.yml>`._
+An example Honeycomb file can be found on `github <https://github.com/Cymmetria/honeycomb/blob/master/honeycomb.yml>`._
 
 .. literalinclude:: ../Honeycomb.yml
    :linenos:

--- a/docs/using-docker.rst
+++ b/docs/using-docker.rst
@@ -1,19 +1,19 @@
-Running honeycomb in a container
+Running Honeycomb in a container
 ================================
 
-The rationale of container support is to allow rapid configuration and deployment so launching honeypots would be simple and easy.
+The rationale of container support is to allow rapid configuration and deployment so that launching honeypots would be simple and easy.
 
-Since honeycomb is a standalone runner for services and integrations, it doesn't make sense for it to orchestrate deployment of external honeypots using docker. Instead, honeycomb itself could be run as a container.
+Since Honeycomb is a standalone runner for services and integrations, it doesn't make sense for it to orchestrate deployment of external honeypots using docker. Instead, Honeycomb itself could be run as a container.
 
-This means the goal is to allow simple configuration that can be passed on to honeycomb and launch services with integration at ease.
+This means the goal is to allow simple configuration that can be passed on to Honeycomb and launch services with integrations easily.
 
-To launch a honeycomb service with configured integration, the user needs to type in several commands to install a service, install an integration, configure that integration and finally run the service with optional parameters.
+To launch a Honeycomb service with a configured integration, the user needs to type in several commands to install a service, install an integration, configure that integration and finally run the service with optional parameters.
 
-This actually resembles configuring a docker environment, where the user needs to type in several commands to define volumes, networks, and finally run a the desired container.
+This actually resembles configuring a docker environment, where the user needs to type in several commands to define volumes, networks, and finally run the desired container.
 
-A yml configuration that specifies all of the desired configurations (services, integrations, etc.) will be supplied to honeycomb, and it will work like a state-machine to reach the desired state before finally running the service.
+A yml configuration that specifies all of the desired configurations (services, integrations, etc.) will be supplied to Honeycomb, and it will work like a state-machine to reach the desired state before finally running the service.
 
-An example honeycomb file can be found on `github <https://github.com/Cymmetria/honeycomb/blob/master/honeycomb.yml>`_
+An example Honeycomb file can be found on `github <https://github.com/Cymmetria/Honeycomb/blob/master/Honeycomb.yml>`._
 
-.. literalinclude:: ../honeycomb.yml
+.. literalinclude:: ../Honeycomb.yml
    :linenos:

--- a/docs/using-docker.rst
+++ b/docs/using-docker.rst
@@ -13,7 +13,7 @@ This actually resembles configuring a docker environment, where the user needs t
 
 A yml configuration that specifies all of the desired configurations (services, integrations, etc.) will be supplied to Honeycomb, and it will work like a state-machine to reach the desired state before finally running the service.
 
-An example Honeycomb file can be found on `github <https://github.com/Cymmetria/Honeycomb/blob/master/Honeycomb.yml>`._
+An example Honeycomb file can be found on `github <https://github.com/Cymmetria/Honeycomb/blob/master/honeycomb.yml>`._
 
 .. literalinclude:: ../Honeycomb.yml
    :linenos:

--- a/docs/using-docker.rst
+++ b/docs/using-docker.rst
@@ -15,5 +15,5 @@ A yml configuration that specifies all of the desired configurations (services, 
 
 An example Honeycomb file can be found on `github <https://github.com/Cymmetria/honeycomb/blob/master/honeycomb.yml>`._
 
-.. literalinclude:: ../Honeycomb.yml
+.. literalinclude:: ../honeycomb.yml
    :linenos:

--- a/honeycomb/servicemanager/base_service.py
+++ b/honeycomb/servicemanager/base_service.py
@@ -52,7 +52,7 @@ class ServerCustomService(Process):
     def on_server_shutdown(self):
         """Shutdown function of the server.
 
-        Override this and take care of gracefully shutting down you service (e.g., close files)
+        Override this and take care to gracefully shut down your service (e.g., close files)
         """
         raise NotImplementedError
 


### PR DESCRIPTION
Now the "how to write a HC service" guide is accessible from the main page.